### PR TITLE
Errors: properly wrap 'fmt.Errorf' calls

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ func Load(path string) (*Config, error) {
 
 	fullpath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("path %s expansion failed: %v", path, err)
+		return nil, fmt.Errorf("path %s expansion failed: %w", path, err)
 	}
 
 	var cfg Config

--- a/internal/provider/pd/client.go
+++ b/internal/provider/pd/client.go
@@ -52,7 +52,7 @@ func (c *client) ping() error {
 	ctx := context.Background()
 	resp, err := c.underlying.ListAbilitiesWithContext(ctx)
 	if err != nil {
-		return fmt.Errorf("pagerduty list abilities: %v", err)
+		return fmt.Errorf("pagerduty list abilities: %w", err)
 	}
 	if len(resp.Abilities) <= 0 {
 		return errors.New("pagerduty: missing abilities")

--- a/internal/provider/pd/service.go
+++ b/internal/provider/pd/service.go
@@ -39,7 +39,7 @@ func (c *client) findService(ctx context.Context, name string) (*pagerduty.Servi
 		Offset: 0,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("listing services: %v", err)
+		return nil, fmt.Errorf("listing services: %w", err)
 	}
 
 	for i := range resp.Services {


### PR DESCRIPTION
Use `%w` verb to ensure errors are wrapped, which additionally maintains consistency with the rest of the code base.